### PR TITLE
add devel option for installing beta

### DIFF
--- a/sudolikeaboss.rb
+++ b/sudolikeaboss.rb
@@ -7,6 +7,11 @@ class Sudolikeaboss < Formula
   if Hardware::CPU.is_64_bit?
     url 'http://dl.bintray.com/ravenac95/sudolikeaboss/sudolikeaboss_0.2.1_darwin_amd64.zip'
     sha256 '23c50e9b6190930f1760122a396a1d6778fbd83266eaf3066623954ec7f0aedd'
+
+    devel do
+      url "https://github.com/ravenac95/sudolikeaboss/files/615148/sudolikeaboss_0.3.0-beta1_darwin_amd64.zip"
+      sha256 "a7ea952b83acb29e6cd8f78c575427075b9a5394e4a45d108faff939d4ee6be3"
+    end
   end
 
   depends_on :arch => :intel


### PR DESCRIPTION
Hey there :)
I thought I'd add a devel block in here for all the people who want to try out the beta.
If you accept this, then people can install the beta with 
```brew update --devel sudolikeaboss```
Thanks for all your work on sudolikeaboss.